### PR TITLE
Converting milliseconds to seconds

### DIFF
--- a/08. Security-in-Contracts-and-Unit-Testing/homework/test/test.js
+++ b/08. Security-in-Contracts-and-Unit-Testing/homework/test/test.js
@@ -1,7 +1,7 @@
 const ico = artifacts.require("SimpleICO");
 
 const increaseTime = function(duration) {
-  const id = Date.now()
+  const id = Date.now() / 1000
 
   return new Promise((resolve, reject) => {
     web3.currentProvider.sendAsync({


### PR DESCRIPTION
Date.now() returns a unix timestamp, but in milliseconds - not in seconds
That means that instead using the current date number as 'id',
you are using the equivalent of "Mon, 02 Mar 50195 10:20:44 +0000"