### PR TITLE
refactored the increaseTime function : final

### DIFF
--- a/08. Security-in-Contracts-and-Unit-Testing/homework/test/test.js
+++ b/08. Security-in-Contracts-and-Unit-Testing/homework/test/test.js
@@ -1,8 +1,9 @@
 const ico = artifacts.require("SimpleICO");
 
 const increaseTime = function(duration) {
-  const id = Date.now()
-
+  const id = web3.eth.getBlock(web3.eth.blockNumber).timestamp;
+  console.log("\t\t - attempting to add time : " + duration);
+  
   return new Promise((resolve, reject) => {
     web3.currentProvider.sendAsync({
       jsonrpc: '2.0',
@@ -17,7 +18,10 @@ const increaseTime = function(duration) {
         method: 'evm_mine',
         id: id+1,
       }, (err2, res) => {
-        return err2 ? reject(err2) : resolve(res)
+        if (err2) return reject(err12);
+        var newTimestamp = web3.eth.getBlock(web3.eth.blockNumber).timestamp;
+        console.log("\t\t - time set to : " + newTimestamp);
+        return resolve(newTimestamp);
       })
     })
   })


### PR DESCRIPTION
- Date.now() is in milliseconds - it should not be used in tests, and when it is - it should be devided by 1000 to become an Unix timestamp
- Instead of using the computer time (Date.now() or new Date()) tests should use the last block time (at all places).
- The above is especially true when changing the time of the blockchain. If you call that method twice with the computer's time, the second time's id will be in the past (compared to the previously changed blockchain time).
- I added some logging
- I changed the return type - it now returns the blockchain time after the change is applied.